### PR TITLE
Support conversion between enum and notification name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+.DS_Store

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "857df2b0a677d151f09416a2f7b52209dec2fd4ac6b01a5e76deba28586cc7db",
+  "originHash" : "cf67fa3a4b500c1e656654fb0efe324978b067cef70d01a0acc9ae270543252c",
   "pins" : [
     {
       "identity" : "swift-syntax",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import CompilerPluginSupport
 import PackageDescription
 
 let package = Package(
-  name: "AppbioticMacros",
+  name: "appbiotic-macros-swift",
   platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
   products: [
     .library(
@@ -34,6 +34,12 @@ let package = Package(
       dependencies: [
         "AppbioticMacrosPlugin",
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "AppbioticMacrosUsageTests",
+      dependencies: [
+        "AppbioticMacros"
       ]
     ),
   ]

--- a/Sources/AppbioticMacros/AppbioticMacros.swift
+++ b/Sources/AppbioticMacros/AppbioticMacros.swift
@@ -14,5 +14,5 @@ public macro stringify<T>(_ value: T) -> (T, String) =
   #externalMacro(module: "AppbioticMacrosPlugin", type: "StringifyMacro")
 
 @attached(member, names: arbitrary)
-public macro NotificationNames(prefix: String) =
+public macro NotificationNames(domain: String) =
   #externalMacro(module: "AppbioticMacrosPlugin", type: "NotificationNamesMacro")

--- a/Tests/AppbioticMacrosUsageTests/AppbioticMacroUsageTests.swift
+++ b/Tests/AppbioticMacrosUsageTests/AppbioticMacroUsageTests.swift
@@ -1,0 +1,52 @@
+//  Copyright (c) 2024 Appbiotic Inc.
+//  Licensed under Apache License v2.0 with Runtime Library Exception
+
+import AppbioticMacros
+import XCTest
+
+enum ServiceState2: String, CaseIterable {
+  case stopped
+  case starting
+  case running
+  case stopping
+
+  public init?(notificationName: Notification.Name) {
+    if let domainRange = notificationName.rawValue.firstRange(of: "\(ServiceState.domain)."),
+      domainRange.lowerBound == notificationName.rawValue.startIndex
+    {
+      let eventName = notificationName.rawValue[domainRange.upperBound...]
+      self.init(rawValue: String(eventName))
+    } else {
+      return nil
+    }
+  }
+
+  public var notificationName: Notification.Name {
+    Notification.Name("\(ServiceState.domain).\(self.rawValue)")
+  }
+}
+
+@NotificationNames(domain: "com.example")
+enum ServiceState: String, CaseIterable {
+  case stopped
+  case starting
+  case running
+  case stopping
+}
+
+final class AppbioticMacrosUsageTests: XCTestCase {
+  func testIntoNotificationName() throws {
+    XCTAssertEqual(ServiceState.running.rawValue, "running")
+    XCTAssertEqual(ServiceState.running.notificationName.rawValue, "com.example.running")
+  }
+
+  func testFromNotificationName() throws {
+    XCTAssertEqual(
+      ServiceState(notificationName: Notification.Name("com.example.stopped")), ServiceState.stopped
+    )
+  }
+
+  func testFromNotificationNameFailure() throws {
+    XCTAssertEqual(ServiceState(notificationName: Notification.Name("com.example.closed")), nil)
+  }
+}


### PR DESCRIPTION
Adds requirements that enum be String and CaseIterable, with the later requirement for later feature additions.